### PR TITLE
command: Increase TFU command timeouts

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -169,18 +169,18 @@ pub(crate) const TFUS_DELAY_MS: u32 = 500;
 /// Timeout for completion of TFUs command
 #[allow(dead_code)]
 pub(crate) const TFUS_TIMEOUT_MS: u32 = TFUS_DELAY_MS + 100;
-/// Timeout for completion of TFUi command
+/// Timeout for completion of TFUi command, docs say 100ms, but 200ms is more reliable
 #[allow(dead_code)]
-pub(crate) const TFUI_TIMEOUT_MS: u32 = 100;
-/// Timeout for completion of TFUe command
+pub(crate) const TFUI_TIMEOUT_MS: u32 = 200;
+/// Timeout for completion of TFUe command, docs say 100ms, but 200ms is more reliable
 #[allow(dead_code)]
-pub(crate) const TFUE_TIMEOUT_MS: u32 = 100;
-/// Timeout for completion of TFUd command
+pub(crate) const TFUE_TIMEOUT_MS: u32 = 200;
+/// Timeout for completion of TFUd command, docs say 100ms, but 200ms is more reliable
 #[allow(dead_code)]
-pub(crate) const TFUD_TIMEOUT_MS: u32 = 100;
-/// Timeout for completion of TFUq command
+pub(crate) const TFUD_TIMEOUT_MS: u32 = 200;
+/// Timeout for completion of TFUq command, docs say 100ms, but 200ms is more reliable
 #[allow(dead_code)]
-pub(crate) const TFUQ_TIMEOUT_MS: u32 = 100;
+pub(crate) const TFUQ_TIMEOUT_MS: u32 = 200;
 /// Timeout for completion of reset
 #[allow(dead_code)]
 pub(crate) const RESET_TIMEOUT_MS: u32 = RESET_DELAY_MS + 100;


### PR DESCRIPTION
The 100 ms timeout values come from the hardware documentation, but in practice these values are too tight and can request in false-positive timeouts. Increase to 200 ms.