### PR TITLE
Remove use of embedded-usb-pd `PdController` trait

### DIFF
--- a/src/asynchronous/embassy/fw_update.rs
+++ b/src/asynchronous/embassy/fw_update.rs
@@ -3,7 +3,6 @@ use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::{with_timeout, Delay, Duration};
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::i2c::I2c;
-use embedded_usb_pd::asynchronous::controller::PdController;
 use embedded_usb_pd::{Error, PdError};
 
 use super::Tps6699x;

--- a/src/asynchronous/embassy/fw_update.rs
+++ b/src/asynchronous/embassy/fw_update.rs
@@ -43,7 +43,7 @@ impl<M: RawMutex, B: I2c> UpdateTarget for Tps6699x<'_, M, B> {
     }
 
     /// Attempt to exit fw update mode
-    async fn fw_update_mode_exit(&mut self, _delay: &mut impl DelayNs) -> Result<(), Error<Self::BusError>> {
+    async fn fw_update_mode_exit(&mut self, delay: &mut impl DelayNs) -> Result<(), Error<Self::BusError>> {
         // Reset the controller if we failed to exit fw update mode
         if let Ok(ret) = self
             .execute_command(PORT0, Command::Tfue, TFUE_TIMEOUT_MS, None, None)
@@ -58,7 +58,7 @@ impl<M: RawMutex, B: I2c> UpdateTarget for Tps6699x<'_, M, B> {
 
         // Reset to return to normal operating mode
         info!("Resetting controller");
-        self.reset(&mut Delay).await?;
+        self.reset(delay).await?;
 
         Ok(())
     }


### PR DESCRIPTION
See https://github.com/OpenDevicePartnership/embedded-services/issues/196

~A `cargo update embedded-usb-pd` is necessary to pick up the changes after https://github.com/OpenDevicePartnership/embedded-usb-pd/pull/8 is merged.~

EDIT: Cargo.lock isn't checked in so this can be merged whenever, though it does depend on https://github.com/OpenDevicePartnership/embedded-usb-pd/pull/8.

Closes https://github.com/OpenDevicePartnership/embedded-services/issues/196