### PR TITLE
silence build warning

### DIFF
--- a/src/asynchronous/embassy/fw_update.rs
+++ b/src/asynchronous/embassy/fw_update.rs
@@ -1,6 +1,6 @@
 use bincode::config;
 use embassy_sync::blocking_mutex::raw::RawMutex;
-use embassy_time::{with_timeout, Delay, Duration};
+use embassy_time::{with_timeout, Duration};
 use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::i2c::I2c;
 use embedded_usb_pd::{Error, PdError};


### PR DESCRIPTION
silence the following build warning

warning: unused import: `Delay`
 --> src\asynchronous\embassy\fw_update.rs:3:34
  |
3 | use embassy_time::{with_timeout, Delay, Duration};
  |                                  ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default