### PR TITLE
Change `interrupt_task` to take a slice

### DIFF
--- a/examples/rt685s-evk/src/bin/fw_update.rs
+++ b/examples/rt685s-evk/src/bin/fw_update.rs
@@ -31,7 +31,7 @@ type Interrupt<'a> = pd_controller::Interrupt<'a, NoopRawMutex, Bus<'a>>;
 
 #[embassy_executor::task]
 async fn interrupt_task(mut int_in: Input<'static>, mut interrupt: Interrupt<'static>) {
-    pd_controller::task::interrupt_task(&mut int_in, [&mut interrupt]).await;
+    pd_controller::task::interrupt_task(&mut int_in, [&mut interrupt].as_mut_slice()).await;
 }
 
 #[embassy_executor::main]

--- a/examples/rt685s-evk/src/bin/plug_status.rs
+++ b/examples/rt685s-evk/src/bin/plug_status.rs
@@ -31,7 +31,7 @@ type Interrupt<'a> = pd_controller::Interrupt<'a, NoopRawMutex, Bus<'a>>;
 
 #[embassy_executor::task]
 async fn interrupt_task(mut int_in: Input<'static>, mut interrupt: Interrupt<'static>) {
-    pd_controller::task::interrupt_task(&mut int_in, [&mut interrupt]).await;
+    pd_controller::task::interrupt_task(&mut int_in, [&mut interrupt].as_mut_slice()).await;
 }
 
 #[embassy_executor::main]

--- a/src/asynchronous/embassy/task.rs
+++ b/src/asynchronous/embassy/task.rs
@@ -10,9 +10,9 @@ use crate::{error, warn};
 const INTERRUPT_BACKOFF_MS: u64 = 100;
 
 /// Task to process all given interrupts
-pub async fn interrupt_task<const N: usize, M: RawMutex, B: I2c, INT: Wait + InputPin>(
+pub async fn interrupt_task<M: RawMutex, B: I2c, INT: Wait + InputPin>(
     int: &mut INT,
-    mut interrupts: [&mut Interrupt<'_, M, B>; N],
+    interrupts: &mut [&mut Interrupt<'_, M, B>],
 ) {
     loop {
         if int.wait_for_low().await.is_err() {
@@ -20,7 +20,7 @@ pub async fn interrupt_task<const N: usize, M: RawMutex, B: I2c, INT: Wait + Inp
             continue;
         }
 
-        for interrupt in &mut interrupts {
+        for interrupt in &mut *interrupts {
             if interrupt.process_interrupt(int).await.is_err() {
                 warn!("Error processing interrupt");
             }


### PR DESCRIPTION
This removes a generic parameter and allows some code paths to reduce the amount of generated code.