### PR TITLE
asynchronous: Add `set_unconstrained_power` function

### DIFF
--- a/src/asynchronous/embassy/mod.rs
+++ b/src/asynchronous/embassy/mod.rs
@@ -437,6 +437,12 @@ impl<'a, M: RawMutex, B: I2c> Tps6699x<'a, M, B> {
         let mut inner = self.lock_inner().await;
         inner.get_alt_mode_status(port).await
     }
+
+    /// Set unconstrained power on a port
+    pub async fn set_unconstrained_power(&mut self, port: PortId, enable: bool) -> Result<(), Error<B::Error>> {
+        let mut inner = self.lock_inner().await;
+        inner.set_unconstrained_power(port, enable).await
+    }
 }
 
 impl<'a, M: RawMutex, B: I2c> interrupt::InterruptController for Tps6699x<'a, M, B> {

--- a/src/asynchronous/internal/mod.rs
+++ b/src/asynchronous/internal/mod.rs
@@ -406,6 +406,13 @@ impl<B: I2c> Tps6699x<B> {
             .write_async(|r| *r = config)
             .await
     }
+
+    /// Set unconstrained power on a port
+    pub async fn set_unconstrained_power(&mut self, port: PortId, enable: bool) -> Result<(), Error<B::Error>> {
+        let mut control = self.get_port_control(port).await?;
+        control.set_unconstrained_power(enable);
+        self.set_port_control(port, control).await
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a common port operation. Create a convenience function over the raw register writes.