### PR TITLE
fw_update: Add burst write address constants

### DIFF
--- a/src/asynchronous/fw_update.rs
+++ b/src/asynchronous/fw_update.rs
@@ -20,6 +20,11 @@ use crate::{debug, error, info, trace, warn, PORT0};
 /// Size of args_buffer used for reading various metadata
 const BUFFER_LENGTH: usize = MAX_METADATA_LEN;
 
+/// TPS6699x burst write address 0, the default used by TI FW
+pub const BURST_WRITE_ADDR0: u16 = 0x77;
+/// TPS6699x burst write address 1
+pub const BURST_WRITE_ADDR1: u16 = 0x78;
+
 /// Trait for updating the firmware of a target device
 pub trait UpdateTarget: InterruptController {
     /// Enter FW update mode


### PR DESCRIPTION
FW update contents are send to a special I2C address. By default this address is 0x77. Add constants for 0x77 and 0x78.