### PR TITLE
asynchronous: Add support for `RxSrcCaps` register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "embedded-hal-mock",
  "embedded-io-async",
  "embedded-usb-pd",
+ "heapless",
  "log",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = { version = "0.4.14", optional = true }
 embassy-sync = { git = "https://github.com/embassy-rs/embassy", optional = true }
 embassy-time = { git = "https://github.com/embassy-rs/embassy", optional = true }
 bincode = { version = "2.0.0", default-features = false, features = ["derive"] }
+heapless = { version = "0.8.0", optional = true }
 
 [features]
 default = []
@@ -30,7 +31,7 @@ defmt = [
     "embassy-time?/defmt-timestamp-uptime",
     "embedded-usb-pd/defmt",
 ]
-embassy = ["dep:embassy-sync", "dep:embassy-time"]
+embassy = ["dep:embassy-sync", "dep:embassy-time", "dep:heapless"]
 log = ["dep:log"]
 
 [dev-dependencies]

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io-async",
  "embedded-usb-pd",
+ "heapless 0.8.0",
 ]
 
 [[package]]

--- a/src/asynchronous/embassy/rx_src_caps.rs
+++ b/src/asynchronous/embassy/rx_src_caps.rs
@@ -1,0 +1,68 @@
+//! Higher-level wrapper for the rx src caps register.
+
+use embedded_usb_pd::pdo::source::Pdo;
+
+use crate::registers::rx_src_caps::{NUM_EPR_PDOS, NUM_SPR_PDOS};
+
+/// Higher-level wrapper for the rx src caps register.
+pub struct RxSrcCaps {
+    pub(super) spr: heapless::Vec<Pdo, NUM_SPR_PDOS>,
+    pub(super) epr: heapless::Vec<Pdo, NUM_EPR_PDOS>,
+}
+
+impl RxSrcCaps {
+    /// Return a slice of all SPR PDOs.
+    pub fn spr_as_slice(&self) -> &[Pdo] {
+        self.spr.as_slice()
+    }
+
+    /// Return a mutable slice of all SPR PDOs.
+    pub fn spr_as_mut_slice(&mut self) -> &mut [Pdo] {
+        self.spr.as_mut_slice()
+    }
+
+    /// Return a slice of all EPR PDOs.
+    pub fn epr_as_slice(&self) -> &[Pdo] {
+        self.epr.as_slice()
+    }
+
+    /// Return if any PDOs are present.
+    pub fn is_empty(&self) -> bool {
+        self.spr.len() + self.epr.len() == 0
+    }
+
+    /// Return a mutable slice of all EPR PDOs.
+    pub fn epr_as_mut_slice(&mut self) -> &mut [Pdo] {
+        self.epr.as_mut_slice()
+    }
+
+    /// Iterator over all PDOs
+    pub fn iter(&self) -> impl Iterator<Item = &'_ Pdo> {
+        self.spr.iter().chain(self.epr.iter())
+    }
+
+    /// Iterator over all PDOs
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &'_ mut Pdo> {
+        self.spr.iter_mut().chain(self.epr.iter_mut())
+    }
+
+    /// Iterator over all SPR PDOs
+    pub fn spr_iter(&self) -> impl Iterator<Item = &'_ Pdo> {
+        self.spr.iter()
+    }
+
+    /// Iterator over all SPR PDOs
+    pub fn spr_iter_mut(&mut self) -> impl Iterator<Item = &'_ mut Pdo> {
+        self.spr.iter_mut()
+    }
+
+    /// Iterator over all EPR PDOs
+    pub fn epr_iter(&self) -> impl Iterator<Item = &'_ Pdo> {
+        self.epr.iter()
+    }
+
+    /// Iterator over all EPR PDOs
+    pub fn epr_iter_mut(&mut self) -> impl Iterator<Item = &'_ mut Pdo> {
+        self.epr.iter_mut()
+    }
+}

--- a/src/asynchronous/internal/mod.rs
+++ b/src/asynchronous/internal/mod.rs
@@ -2,9 +2,12 @@
 use device_driver::AsyncRegisterInterface;
 use embedded_hal_async::i2c::I2c;
 use embedded_usb_pd::pdinfo::AltMode;
+use embedded_usb_pd::pdo::source::Pdo;
+use embedded_usb_pd::pdo::ExpectedPdo;
 use embedded_usb_pd::{Error, PdError, PortId};
 
-use crate::{registers, Mode, MAX_SUPPORTED_PORTS, PORT0, PORT1, TPS66993_NUM_PORTS, TPS66994_NUM_PORTS};
+use crate::registers::rx_src_caps::EPR_PDO_START_INDEX;
+use crate::{registers, DeviceError, Mode, MAX_SUPPORTED_PORTS, PORT0, PORT1, TPS66993_NUM_PORTS, TPS66994_NUM_PORTS};
 
 mod command;
 
@@ -530,6 +533,49 @@ impl<B: I2c> Tps6699x<B> {
             .await?;
         Ok(buf.into())
     }
+
+    /// Get RX source capabilities
+    ///
+    /// Returns (num pdos placed in out_spr_pdos , num pdos placed in out_epr_pdos)
+    pub async fn get_rx_src_caps(
+        &mut self,
+        port: PortId,
+        out_spr_pdos: &mut [Pdo],
+        out_epr_pdos: &mut [Pdo],
+    ) -> Result<(usize, usize), DeviceError<B::Error, ExpectedPdo>> {
+        // Clamp to the maximum number of PDOs
+        let num_pdos = if !out_epr_pdos.is_empty() {
+            EPR_PDO_START_INDEX + out_epr_pdos.len()
+        } else {
+            // SPR PDOs start at index 0
+            out_spr_pdos.len()
+        }
+        .min(registers::rx_src_caps::TOTAL_PDOS);
+
+        // 4 bytes for each PDO
+        let read_size = registers::rx_src_caps::HEADER_LEN + 4 * num_pdos;
+        let mut buf = [0u8; registers::rx_src_caps::LEN];
+        self.borrow_port(port)
+            .map_err(DeviceError::from)?
+            .into_registers()
+            .interface()
+            .read_register(registers::rx_src_caps::ADDR, (read_size * 8) as u32, &mut buf)
+            .await?;
+
+        let rx_source_caps = registers::rx_src_caps::RxSrcCaps::try_from(buf).map_err(DeviceError::Other)?;
+        let num_sprs = out_spr_pdos.len().min(rx_source_caps.num_valid_pdos() as usize);
+        for (i, pdo) in out_spr_pdos.iter_mut().enumerate().take(num_sprs) {
+            // SPR PDOs start at index 0
+            *pdo = rx_source_caps[i];
+        }
+
+        let num_eprs = out_epr_pdos.len().min(rx_source_caps.num_valid_epr_pdos() as usize);
+        for (i, pdo) in out_epr_pdos.iter_mut().enumerate().take(num_eprs) {
+            *pdo = rx_source_caps[EPR_PDO_START_INDEX + i];
+        }
+
+        Ok((num_sprs, num_eprs))
+    }
 }
 
 #[cfg(test)]
@@ -540,8 +586,11 @@ mod test {
     use device_driver::AsyncRegisterInterface;
     use embedded_hal_async::i2c::ErrorType;
     use embedded_hal_mock::eh1::i2c::{Mock, Transaction};
+    use embedded_usb_pd::pdo::source::Pdo;
+    use registers::rx_src_caps::ADDR;
 
     use super::*;
+    use crate::registers::rx_src_caps::{self};
     use crate::test::*;
     use crate::{ADDR0, ADDR1, PORT0, PORT1};
 
@@ -913,5 +962,56 @@ mod test {
         let mock = Mock::new(&[]);
         let mut tps6699x: Tps6699x<Mock> = Tps6699x::new_tps66994(mock, ADDR1);
         test_get_customer_use(&mut tps6699x, PORT0_ADDR1, TEST_CUSTOMER_USE).await;
+    }
+
+    /// Test reading SPR PDOs
+    #[tokio::test]
+    async fn test_get_rx_src_caps_spr() {
+        let mock = Mock::new(&[]);
+        let mut tps6699x: Tps6699x<Mock> = Tps6699x::new_tps66994(mock, ADDR0);
+
+        let mut buf = [0u8; rx_src_caps::LEN + 1];
+        // Register length
+        buf[0] = rx_src_caps::LEN as u8;
+        // Set header: low 3 bits are SPR PDO count
+        buf[1] = 0xa; // 2 SPR PDOs, 1 EPR PDOs
+                      // Fill PDOs with test data
+                      // SPR PDO 0 - Fixed PDO at 5V, 3A, 100% peak current
+        buf[2..6].copy_from_slice(&TEST_SRC_PDO_FIXED_5V3A_RAW.to_le_bytes());
+        // SPR PDO 1 - Fixed PDO at 5V, 1.5A, 100% peak current
+        buf[6..10].copy_from_slice(&TEST_SRC_PDO_FIXED_5V1A5_RAW.to_le_bytes());
+        // Fake SPR, used to test overread
+        buf[10..14].copy_from_slice(&TEST_SRC_PDO_FIXED_5V900MA_RAW.to_le_bytes());
+        // EPR PDO 0 - Fixed PDO at 28V, 5A, 100% peak current
+        buf[30..34].copy_from_slice(&TEST_SRC_EPR_PDO_FIXED_28V5A_RAW.to_le_bytes());
+        // Fake EPR, used to test overread
+        buf[34..38].copy_from_slice(&TEST_SRC_EPR_PDO_FIXED_28V3A_RAW.to_le_bytes());
+        // Fake EPR, used to test overread
+        buf[38..42].copy_from_slice(&TEST_SRC_EPR_PDO_FIXED_28V1A5_RAW.to_le_bytes());
+
+        // Expect a read of 14 bytes (header + 3 PDOs)
+        tps6699x
+            .bus
+            .update_expectations(&[Transaction::write_read(PORT0_ADDR0, std::vec![ADDR], {
+                Vec::from(buf)
+            })]);
+
+        // Read PDOs, with attempted overread
+        let mut out_spr_pdos = [Pdo::default(); 3];
+        let mut out_epr_pdos = [Pdo::default(); 2];
+        let (num_pdos, num_epr_pdos) = tps6699x
+            .get_rx_src_caps(PORT0, &mut out_spr_pdos, &mut out_epr_pdos)
+            .await
+            .unwrap();
+        tps6699x.bus.done();
+
+        assert_eq!(num_pdos, 2);
+        assert_eq!(num_epr_pdos, 1);
+        assert_eq!(out_spr_pdos[0], TEST_SRC_PDO_FIXED_5V3A);
+        assert_eq!(out_spr_pdos[1], TEST_SRC_PDO_FIXED_5V1A5);
+        assert_eq!(out_spr_pdos[2], Pdo::default());
+
+        assert_eq!(out_epr_pdos[0], TEST_SRC_EPR_PDO_FIXED_28V5A);
+        assert_eq!(out_epr_pdos[1], Pdo::default());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,8 @@ pub(crate) mod test {
     use bincode::encode_into_slice;
     use embedded_hal_async::delay::DelayNs;
     use embedded_hal_mock::eh1::i2c::Transaction;
+    use embedded_usb_pd::pdo::source::FixedFlags;
+    use embedded_usb_pd::pdo::{self, MA10_UNIT, MV50_UNIT};
     use tokio::time::sleep;
 
     use super::*;
@@ -311,4 +313,65 @@ pub(crate) mod test {
 
         buffer
     }
+
+    // The current USB PD code is focused on decoding PDOs, not creating them
+    // TODO: https://github.com/OpenDevicePartnership/embedded-usb-pd/issues/30
+    /// Create a test source PDO fixed raw value
+    pub const fn test_src_pdo_fixed_raw(voltage_mv: u16, current_ma: u16) -> u32 {
+        (((voltage_mv / MV50_UNIT) as u32) << 10) | (current_ma / MA10_UNIT) as u32
+    }
+
+    pub const fn test_src_pdo_fixed_flags() -> FixedFlags {
+        FixedFlags {
+            dual_role_power: false,
+            usb_suspend_supported: false,
+            unconstrained_power: false,
+            usb_comms_capable: false,
+            dual_role_data: false,
+            unchunked_extended_messages_support: false,
+            epr_capable: false,
+        }
+    }
+
+    /// Test source PDO fixed 5V 3A raw
+    pub const TEST_SRC_PDO_FIXED_5V3A_RAW: u32 = test_src_pdo_fixed_raw(5000, 3000);
+    /// Test source PDO fixed 5V 3A
+    pub const TEST_SRC_PDO_FIXED_5V3A: pdo::source::Pdo = pdo::source::Pdo::Fixed(pdo::source::FixedData {
+        flags: test_src_pdo_fixed_flags(),
+        voltage_mv: 5000,
+        current_ma: 3000,
+        peak_current: pdo::source::PeakCurrent::Pct100,
+    });
+
+    /// Test source PDO fixed 5V 1.5A raw
+    pub const TEST_SRC_PDO_FIXED_5V1A5_RAW: u32 = test_src_pdo_fixed_raw(5000, 1500);
+    /// Test source PDO fixed 5V 1.5A
+    pub const TEST_SRC_PDO_FIXED_5V1A5: pdo::source::Pdo = pdo::source::Pdo::Fixed(pdo::source::FixedData {
+        flags: test_src_pdo_fixed_flags(),
+        voltage_mv: 5000,
+        current_ma: 1500,
+        peak_current: pdo::source::PeakCurrent::Pct100,
+    });
+
+    /// Test source PDO fixed 5V 900mA raw
+    pub const TEST_SRC_PDO_FIXED_5V900MA_RAW: u32 = test_src_pdo_fixed_raw(5000, 900);
+
+    /// Test source EPR PDO fixed 28V 5A raw
+    pub const TEST_SRC_EPR_PDO_FIXED_28V5A_RAW: u32 = test_src_pdo_fixed_raw(28000, 5000);
+    /// Test source EPR PDO fixed 28V 5A
+    pub const TEST_SRC_EPR_PDO_FIXED_28V5A: pdo::source::Pdo = pdo::source::Pdo::Fixed(pdo::source::FixedData {
+        flags: test_src_pdo_fixed_flags(),
+        voltage_mv: 28000,
+        current_ma: 5000,
+        peak_current: pdo::source::PeakCurrent::Pct100,
+    });
+
+    /// Test source EPR PDO fixed 28V 3A raw
+    pub const TEST_SRC_EPR_PDO_FIXED_28V3A_RAW: u32 = test_src_pdo_fixed_raw(28000, 3000);
+
+    /// Test source EPR PDO fixed 28V 1.5A raw
+    pub const TEST_SRC_EPR_PDO_FIXED_28V1A5_RAW: u32 = test_src_pdo_fixed_raw(28000, 1500);
+
+    /// Test invalid source APDO raw, invalid due to APDO type being 11b
+    pub const TEST_SRC_APDO_INVALID_RAW: u32 = 0xF0000000;
 }

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -9,6 +9,7 @@ pub mod boot_flags;
 pub mod dp_status;
 pub mod port_config;
 pub mod rx_other_vdm;
+pub mod rx_src_caps;
 
 device_driver::create_device!(
     device_name: Registers,

--- a/src/registers/rx_src_caps.rs
+++ b/src/registers/rx_src_caps.rs
@@ -1,0 +1,222 @@
+use core::ops::{Index, IndexMut};
+
+use bitfield::bitfield;
+use embedded_usb_pd::pdo::source::Pdo;
+use embedded_usb_pd::pdo::ExpectedPdo;
+
+/// Register address
+pub const ADDR: u8 = 0x30;
+
+/// Length of the register in bytes
+pub const LEN: usize = 45;
+
+/// Total number of PDOs supported
+pub const TOTAL_PDOS: usize = NUM_SPR_PDOS + NUM_EPR_PDOS;
+
+/// Total length in bytes of the register header
+/// [`RxSrcCapsRaw::num_valid_pdos`], [`RxSrcCapsRaw::num_valid_epr_pdos`] and [`RxSrcCapsRaw::last_src_cap_is_epr`]
+pub const HEADER_LEN: usize = 1;
+
+/// Starting index of SPR PDOs in the register
+pub const SPR_PDO_START_INDEX: usize = 0;
+/// Number of SPR PDOs
+pub const NUM_SPR_PDOS: usize = 7;
+
+/// Starting index of EPR PDOs in the register
+pub const EPR_PDO_START_INDEX: usize = SPR_PDO_START_INDEX + NUM_SPR_PDOS;
+/// Number of EPR PDOs
+pub const NUM_EPR_PDOS: usize = 4;
+
+bitfield! {
+    /// Received source capabilities register
+    #[derive(Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    struct RxSrcCapsRaw([u8]);
+    impl Debug;
+
+    /// Number of Valid PDOs
+    pub u8, num_valid_pdos, set_num_valid_pdos: 2, 0;
+    /// Number of Valid EPR PDOs
+    pub u8, num_valid_epr_pdos, set_num_valid_epr_pdos: 5, 3;
+    /// Last Src Cap Received is EPR
+    pub bool, last_src_cap_is_epr, set_last_src_cap_is_epr: 6;
+
+    /// Standard PDO 0
+    pub u32, pdo0, set_pdo0: 39, 8;
+    /// Standard PDO 1
+    pub u32, pdo1, set_pdo1: 71, 40;
+    /// Standard PDO 2
+    pub u32, pdo2, set_pdo2: 103, 72;
+    /// Standard PDO 3
+    pub u32, pdo3, set_pdo3: 135, 104;
+    /// Standard PDO 4
+    pub u32, pdo4, set_pdo4: 167, 136;
+    /// Standard PDO 5
+    pub u32, pdo5, set_pdo5: 199, 168;
+    /// Standard PDO 6
+    pub u32, pdo6, set_pdo6: 231, 200;
+
+    /// EPR PDO 0
+    pub u32, epr_pdo0, set_epr_pdo0: 263, 232;
+    /// EPR PDO 1
+    pub u32, epr_pdo1, set_epr_pdo1: 295, 264;
+    /// EPR PDO 2
+    pub u32, epr_pdo2, set_epr_pdo2: 327, 296;
+    /// EPR PDO 3
+    pub u32, epr_pdo3, set_epr_pdo3: 359, 328;
+}
+
+/// High-level wrapper around [`RxSrcCapsRaw`].
+#[derive(Clone, Copy, Debug)]
+pub struct RxSrcCaps {
+    /// Number of valid standard PDOs
+    num_valid_pdos: u8,
+    /// Number of valid EPR PDOs
+    num_valid_epr_pdos: u8,
+    /// Last source capabilities received is EPR
+    last_src_cap_is_epr: bool,
+    /// PDOs
+    pdos: [Pdo; TOTAL_PDOS],
+}
+
+impl RxSrcCaps {
+    /// Get number of valid standard PDOs
+    pub fn num_valid_pdos(&self) -> u8 {
+        self.num_valid_pdos
+    }
+
+    /// Set number of valid standard PDOs
+    pub fn set_num_valid_pdos(&mut self, num: u8) -> &mut Self {
+        self.num_valid_pdos = num;
+        self
+    }
+
+    /// Get number of valid EPR PDOs
+    pub fn num_valid_epr_pdos(&self) -> u8 {
+        self.num_valid_epr_pdos
+    }
+
+    /// Set number of valid EPR PDOs
+    pub fn set_num_valid_epr_pdos(&mut self, num: u8) -> &mut Self {
+        self.num_valid_epr_pdos = num;
+        self
+    }
+
+    /// Get whether last source cap received is EPR
+    pub fn last_src_cap_is_epr(&self) -> bool {
+        self.last_src_cap_is_epr
+    }
+
+    /// Set whether last source cap received is EPR
+    pub fn set_last_src_cap_is_epr(&mut self, is_epr: bool) -> &mut Self {
+        self.last_src_cap_is_epr = is_epr;
+        self
+    }
+}
+
+impl Index<usize> for RxSrcCaps {
+    type Output = Pdo;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if index < TOTAL_PDOS {
+            &self.pdos[index]
+        } else {
+            panic!("Index out of bounds: {}", index);
+        }
+    }
+}
+
+impl IndexMut<usize> for RxSrcCaps {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        if index < TOTAL_PDOS {
+            &mut self.pdos[index]
+        } else {
+            panic!("Index out of bounds: {}", index);
+        }
+    }
+}
+
+impl TryFrom<[u8; LEN]> for RxSrcCaps {
+    type Error = ExpectedPdo;
+
+    fn try_from(raw: [u8; LEN]) -> Result<Self, Self::Error> {
+        let raw = RxSrcCapsRaw(raw);
+        let num_valid_pdos = raw.num_valid_pdos() as usize;
+        let num_valid_epr_pdos = raw.num_valid_epr_pdos() as usize;
+
+        let mut pdos = [Pdo::default(); TOTAL_PDOS];
+
+        // Decode only valid SPR PDOs
+        for (i, pdo) in pdos.iter_mut().enumerate().take(num_valid_pdos) {
+            *pdo = Pdo::try_from(match i {
+                0 => raw.pdo0(),
+                1 => raw.pdo1(),
+                2 => raw.pdo2(),
+                3 => raw.pdo3(),
+                4 => raw.pdo4(),
+                5 => raw.pdo5(),
+                6 => raw.pdo6(),
+                _ => unreachable!(),
+            })?;
+        }
+
+        // Decode only valid EPR PDOs
+        for (i, pdo) in pdos
+            .iter_mut()
+            .skip(EPR_PDO_START_INDEX)
+            .enumerate()
+            .take(num_valid_epr_pdos)
+        {
+            *pdo = Pdo::try_from(match i {
+                0 => raw.epr_pdo0(),
+                1 => raw.epr_pdo1(),
+                2 => raw.epr_pdo2(),
+                3 => raw.epr_pdo3(),
+                _ => unreachable!(),
+            })?;
+        }
+
+        Ok(RxSrcCaps {
+            num_valid_pdos: raw.num_valid_pdos(),
+            num_valid_epr_pdos: raw.num_valid_epr_pdos(),
+            last_src_cap_is_epr: raw.last_src_cap_is_epr(),
+            pdos,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::{
+        TEST_SRC_APDO_INVALID_RAW, TEST_SRC_EPR_PDO_FIXED_28V5A, TEST_SRC_EPR_PDO_FIXED_28V5A_RAW,
+        TEST_SRC_PDO_FIXED_5V1A5, TEST_SRC_PDO_FIXED_5V1A5_RAW, TEST_SRC_PDO_FIXED_5V3A, TEST_SRC_PDO_FIXED_5V3A_RAW,
+    };
+
+    #[test]
+    fn test_try_from() {
+        let mut buf = [0u8; LEN];
+        // Set header: low 3 bits are SPR PDO count
+        buf[0] = 0xa; // 2 SPR PDOs, 1 EPR PDOs
+                      // Fill PDOs with test data
+                      // SPR PDO 0 - Fixed PDO at 5V, 3A, 100% peak current
+        buf[1..5].copy_from_slice(&TEST_SRC_PDO_FIXED_5V3A_RAW.to_le_bytes());
+        // SPR PDO 1 - Fixed PDO at 5V, 1.5A, 100% peak current
+        buf[5..9].copy_from_slice(&TEST_SRC_PDO_FIXED_5V1A5_RAW.to_le_bytes());
+        // Fake SPR, used to test overread
+        buf[9..13].copy_from_slice(&TEST_SRC_APDO_INVALID_RAW.to_le_bytes());
+        // EPR PDO 0 - Fixed PDO at 28V, 5A, 100% peak current
+        buf[29..33].copy_from_slice(&TEST_SRC_EPR_PDO_FIXED_28V5A_RAW.to_le_bytes());
+        // Fake EPR, used to test overread
+        buf[33..37].copy_from_slice(&TEST_SRC_APDO_INVALID_RAW.to_le_bytes());
+        // Fake EPR, used to test overread
+        buf[37..41].copy_from_slice(&TEST_SRC_APDO_INVALID_RAW.to_le_bytes());
+
+        let rx_src_caps = RxSrcCaps::try_from(buf).unwrap();
+        assert_eq!(rx_src_caps.num_valid_pdos(), 2);
+        assert_eq!(rx_src_caps.num_valid_epr_pdos(), 1);
+        assert_eq!(rx_src_caps[0], TEST_SRC_PDO_FIXED_5V3A);
+        assert_eq!(rx_src_caps[1], TEST_SRC_PDO_FIXED_5V1A5);
+        assert_eq!(rx_src_caps[EPR_PDO_START_INDEX], TEST_SRC_EPR_PDO_FIXED_28V5A);
+    }
+}


### PR DESCRIPTION
The active PDO register does not actually have the complete PDO. When we're sinking some flags in the current PDO are only present in the fixed 5V source capability PDO. Add a function to allow reading received source capabilities.