### PR TITLE
command: Change `TFUc` timeout to standard reset timeout

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -131,7 +131,7 @@ impl Command {
         match self {
             Command::Tfus => TFUS_DELAY_MS + 100,
             Command::Tfui | Command::Tfue | Command::Tfud | Command::Tfuq => 200, // docs say 100ms, but 200ms is more reliable
-            Command::Gaid => RESET_DELAY_MS + 100,
+            Command::Gaid | Command::Tfuc => RESET_DELAY_MS + 100,
             Command::Srdy | Command::Sryr => 250, // determined by experimentation
             Command::Trig => 500,                 // determined by experimentation
             _ => 1000,


### PR DESCRIPTION
This command resets the controller so it should have the same timeout as `GAID`.