### PR TITLE
Update `embedded-usb-pd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#98ca3abe6e5014aa63826a3e7ca4eb59ed2b059e"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#ef0a85e2708af97849940dcc14fc12cca95e8b1c"
 dependencies = [
  "aquamarine",
  "bincode",

--- a/src/asynchronous/embassy/rx_caps.rs
+++ b/src/asynchronous/embassy/rx_caps.rs
@@ -99,22 +99,22 @@ mod tests {
 
     fn make_src_caps() -> RxCaps<source::Pdo> {
         let spr = source::Pdo::Fixed(SrcFixedData {
-            flags: Default::default(),
             voltage_mv: 5000,
             current_ma: 3000,
             peak_current: source::PeakCurrent::Pct100,
+            ..Default::default()
         });
         let epr0 = source::Pdo::Fixed(SrcFixedData {
-            flags: Default::default(),
             voltage_mv: 28000,
             current_ma: 3000,
             peak_current: source::PeakCurrent::Pct100,
+            ..Default::default()
         });
         let epr1 = source::Pdo::Fixed(SrcFixedData {
-            flags: Default::default(),
             voltage_mv: 28000,
             current_ma: 5000,
             peak_current: source::PeakCurrent::Pct100,
+            ..Default::default()
         });
         RxCaps {
             spr: heapless::Vec::from_iter([spr]),
@@ -124,34 +124,22 @@ mod tests {
 
     fn make_snk_caps() -> RxCaps<sink::Pdo> {
         let spr0 = sink::Pdo::Fixed(SnkFixedData {
-            dual_role_power: false,
-            higher_capability: false,
-            unconstrained_power: false,
-            usb_comms_capable: false,
-            dual_role_data: false,
             frs_required_current: sink::FrsRequiredCurrent::None,
             voltage_mv: 5000,
             operational_current_ma: 900,
+            ..Default::default()
         });
         let spr1 = sink::Pdo::Fixed(SnkFixedData {
-            dual_role_power: false,
-            higher_capability: false,
-            unconstrained_power: false,
-            usb_comms_capable: false,
-            dual_role_data: false,
             frs_required_current: sink::FrsRequiredCurrent::None,
             voltage_mv: 5000,
             operational_current_ma: 3000,
+            ..Default::default()
         });
         let epr = sink::Pdo::Fixed(SnkFixedData {
-            dual_role_power: false,
-            higher_capability: false,
-            unconstrained_power: false,
-            usb_comms_capable: false,
-            dual_role_data: false,
             frs_required_current: sink::FrsRequiredCurrent::None,
             voltage_mv: 20000,
             operational_current_ma: 3000,
+            ..Default::default()
         });
         RxCaps {
             spr: heapless::Vec::from_iter([spr0, spr1]),
@@ -169,28 +157,28 @@ mod tests {
         assert_eq!(
             generic.spr[0],
             pdo::Pdo::Source(source::Pdo::Fixed(SrcFixedData {
-                flags: Default::default(),
                 voltage_mv: 5000,
                 current_ma: 3000,
                 peak_current: source::PeakCurrent::Pct100,
+                ..Default::default()
             }))
         );
         assert_eq!(
             generic.epr[0],
             pdo::Pdo::Source(source::Pdo::Fixed(SrcFixedData {
-                flags: Default::default(),
                 voltage_mv: 28000,
                 current_ma: 3000,
                 peak_current: source::PeakCurrent::Pct100,
+                ..Default::default()
             }))
         );
         assert_eq!(
             generic.epr[1],
             pdo::Pdo::Source(source::Pdo::Fixed(SrcFixedData {
-                flags: Default::default(),
                 voltage_mv: 28000,
                 current_ma: 5000,
                 peak_current: source::PeakCurrent::Pct100,
+                ..Default::default()
             }))
         );
     }
@@ -205,40 +193,28 @@ mod tests {
         assert_eq!(
             generic.spr[0],
             pdo::Pdo::Sink(sink::Pdo::Fixed(SnkFixedData {
-                dual_role_power: false,
-                higher_capability: false,
-                unconstrained_power: false,
-                usb_comms_capable: false,
-                dual_role_data: false,
                 frs_required_current: sink::FrsRequiredCurrent::None,
                 voltage_mv: 5000,
                 operational_current_ma: 900,
+                ..Default::default()
             }))
         );
         assert_eq!(
             generic.spr[1],
             pdo::Pdo::Sink(sink::Pdo::Fixed(SnkFixedData {
-                dual_role_power: false,
-                higher_capability: false,
-                unconstrained_power: false,
-                usb_comms_capable: false,
-                dual_role_data: false,
                 frs_required_current: sink::FrsRequiredCurrent::None,
                 voltage_mv: 5000,
                 operational_current_ma: 3000,
+                ..Default::default()
             }))
         );
         assert_eq!(
             generic.epr[0],
             pdo::Pdo::Sink(sink::Pdo::Fixed(SnkFixedData {
-                dual_role_power: false,
-                higher_capability: false,
-                unconstrained_power: false,
-                usb_comms_capable: false,
-                dual_role_data: false,
                 frs_required_current: sink::FrsRequiredCurrent::None,
                 voltage_mv: 20000,
                 operational_current_ma: 3000,
+                ..Default::default()
             }))
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,6 @@ pub(crate) mod test {
     use bincode::encode_into_slice;
     use embedded_hal_async::delay::DelayNs;
     use embedded_hal_mock::eh1::i2c::Transaction;
-    use embedded_usb_pd::pdo::source::FixedFlags;
     use embedded_usb_pd::pdo::{self, MA10_UNIT, MV50_UNIT};
     use tokio::time::sleep;
 
@@ -316,36 +315,36 @@ pub(crate) mod test {
         (((voltage_mv / MV50_UNIT) as u32) << 10) | (current_ma / MA10_UNIT) as u32
     }
 
-    pub const fn test_src_pdo_fixed_flags() -> FixedFlags {
-        FixedFlags {
-            dual_role_power: false,
-            usb_suspend_supported: false,
-            unconstrained_power: false,
-            usb_comms_capable: false,
-            dual_role_data: false,
-            unchunked_extended_messages_support: false,
-            epr_capable: false,
-        }
-    }
-
     /// Test source PDO fixed 5V 3A raw
     pub const TEST_SRC_PDO_FIXED_5V3A_RAW: u32 = test_src_pdo_fixed_raw(5000, 3000);
     /// Test source PDO fixed 5V 3A
     pub const TEST_SRC_PDO_FIXED_5V3A: pdo::source::Pdo = pdo::source::Pdo::Fixed(pdo::source::FixedData {
-        flags: test_src_pdo_fixed_flags(),
         voltage_mv: 5000,
         current_ma: 3000,
         peak_current: pdo::source::PeakCurrent::Pct100,
+        dual_role_power: false,
+        dual_role_data: false,
+        usb_suspend_supported: false,
+        unconstrained_power: false,
+        usb_comms_capable: false,
+        epr_capable: false,
+        unchunked_extended_messages_support: false,
     });
 
     /// Test source PDO fixed 5V 1.5A raw
     pub const TEST_SRC_PDO_FIXED_5V1A5_RAW: u32 = test_src_pdo_fixed_raw(5000, 1500);
     /// Test source PDO fixed 5V 1.5A
     pub const TEST_SRC_PDO_FIXED_5V1A5: pdo::source::Pdo = pdo::source::Pdo::Fixed(pdo::source::FixedData {
-        flags: test_src_pdo_fixed_flags(),
         voltage_mv: 5000,
         current_ma: 1500,
         peak_current: pdo::source::PeakCurrent::Pct100,
+        dual_role_power: false,
+        dual_role_data: false,
+        usb_suspend_supported: false,
+        unconstrained_power: false,
+        usb_comms_capable: false,
+        epr_capable: false,
+        unchunked_extended_messages_support: false,
     });
 
     /// Test source PDO fixed 5V 900mA raw
@@ -355,10 +354,16 @@ pub(crate) mod test {
     pub const TEST_SRC_EPR_PDO_FIXED_28V5A_RAW: u32 = test_src_pdo_fixed_raw(28000, 5000);
     /// Test source EPR PDO fixed 28V 5A
     pub const TEST_SRC_EPR_PDO_FIXED_28V5A: pdo::source::Pdo = pdo::source::Pdo::Fixed(pdo::source::FixedData {
-        flags: test_src_pdo_fixed_flags(),
         voltage_mv: 28000,
         current_ma: 5000,
         peak_current: pdo::source::PeakCurrent::Pct100,
+        dual_role_power: false,
+        dual_role_data: false,
+        usb_suspend_supported: false,
+        unconstrained_power: false,
+        usb_comms_capable: false,
+        epr_capable: false,
+        unchunked_extended_messages_support: false,
     });
 
     /// Test source EPR PDO fixed 28V 3A raw

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,22 @@ pub(crate) mod test {
         (((voltage_mv / MV50_UNIT) as u32) << 10) | (current_ma / MA10_UNIT) as u32
     }
 
+    pub const fn test_src_pdo_fixed_flags() -> pdo::source::FixedData {
+        pdo::source::FixedData {
+            dual_role_power: false,
+            usb_suspend_supported: false,
+            unconstrained_power: false,
+            usb_comms_capable: false,
+            dual_role_data: false,
+            unchunked_extended_messages_support: false,
+            epr_capable: false,
+            // Other values don't matter because we're just using this for the flags.
+            peak_current: pdo::source::PeakCurrent::Pct100,
+            voltage_mv: 0,
+            current_ma: 0,
+        }
+    }
+
     /// Test source PDO fixed 5V 3A raw
     pub const TEST_SRC_PDO_FIXED_5V3A_RAW: u32 = test_src_pdo_fixed_raw(5000, 3000);
     /// Test source PDO fixed 5V 3A
@@ -322,13 +338,7 @@ pub(crate) mod test {
         voltage_mv: 5000,
         current_ma: 3000,
         peak_current: pdo::source::PeakCurrent::Pct100,
-        dual_role_power: false,
-        dual_role_data: false,
-        usb_suspend_supported: false,
-        unconstrained_power: false,
-        usb_comms_capable: false,
-        epr_capable: false,
-        unchunked_extended_messages_support: false,
+        ..test_src_pdo_fixed_flags()
     });
 
     /// Test source PDO fixed 5V 1.5A raw
@@ -338,13 +348,7 @@ pub(crate) mod test {
         voltage_mv: 5000,
         current_ma: 1500,
         peak_current: pdo::source::PeakCurrent::Pct100,
-        dual_role_power: false,
-        dual_role_data: false,
-        usb_suspend_supported: false,
-        unconstrained_power: false,
-        usb_comms_capable: false,
-        epr_capable: false,
-        unchunked_extended_messages_support: false,
+        ..test_src_pdo_fixed_flags()
     });
 
     /// Test source PDO fixed 5V 900mA raw
@@ -357,13 +361,7 @@ pub(crate) mod test {
         voltage_mv: 28000,
         current_ma: 5000,
         peak_current: pdo::source::PeakCurrent::Pct100,
-        dual_role_power: false,
-        dual_role_data: false,
-        usb_suspend_supported: false,
-        unconstrained_power: false,
-        usb_comms_capable: false,
-        epr_capable: false,
-        unchunked_extended_messages_support: false,
+        ..test_src_pdo_fixed_flags()
     });
 
     /// Test source EPR PDO fixed 28V 3A raw


### PR DESCRIPTION
The checked-in lock file referred to an old version of this crate. Pull in the latest version and fix test errors.