### PR TITLE
Point to v0.1.0 of embedded-usb-pd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#21d0e228d21ddc6ccaeffc01d98ef9a5b87941ef"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
 dependencies = [
  "aquamarine",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bitfield = "0.19.0"
 embedded-io-async = "0.6.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false }
 # When updating `device-driver`, also update the version of device-driver-cli in the README and in the device-driver.yml workflow.
 device-driver = { version = "1.0.9", default-features = false }
 defmt = { version = "0.3.0", optional = true }

--- a/examples/rt685s-evk/Cargo.lock
+++ b/examples/rt685s-evk/Cargo.lock
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "device-driver"
-version = "1.0.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c424cfcc4a418769975185d1d9066ad07fa05cb343fda8ea0adf98a9e9d195d2"
+checksum = "c2e4547bd66511372d2a38ac3c1b2892c7ebf83cf0d5411c3406e496c85a1d96"
 dependencies = [
  "defmt 0.3.100",
  "embedded-io 0.6.1",
@@ -561,7 +561,7 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd#21d0e228d21ddc6ccaeffc01d98ef9a5b87941ef"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
 dependencies = [
  "aquamarine",
  "bincode",

--- a/examples/rt685s-evk/Cargo.toml
+++ b/examples/rt685s-evk/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.30", default-features = false, features = [
 ] }
 rand = { version = "0.8.5", default-features = false }
 
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", default-features = false }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false }
 
 mimxrt600-fcb = "0.1.0"
 tps6699x = { path = "../../.", features = ["defmt", "embassy"] }


### PR DESCRIPTION
This pull request updates the `embedded-usb-pd` dependency in both the main project and the `rt685s-evk` example to use a specific tagged release (`v0.1.0`) instead of tracking the latest commit on the repository. This change ensures reproducible builds by pinning the dependency to a known version.

Dependency version pinning:

* Updated the `embedded-usb-pd` dependency in `Cargo.toml` to use the `v0.1.0` tag instead of the latest commit from the `OpenDevicePartnership/embedded-usb-pd` repository.
* Updated the `embedded-usb-pd` dependency in `examples/rt685s-evk/Cargo.toml` to use the `v0.1.0` tag for consistency and reproducibility.